### PR TITLE
Fix Windows SSPI compiler warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "dnspx"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dnspx"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/src/adapters/resolver/sspi_auth.rs
+++ b/src/adapters/resolver/sspi_auth.rs
@@ -9,7 +9,7 @@ use tokio::sync::RwLock;
 use tracing::{debug, error, warn};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SspiAuthState {
+pub(super) enum SspiAuthState {
     Initial,
     NegotiateSent,
     ChallengeReceived,
@@ -18,7 +18,7 @@ pub enum SspiAuthState {
 }
 
 #[derive(Debug)]
-pub struct SspiAuthManager {
+pub(super) struct SspiAuthManager {
     target_spn: String,
     username: Option<String>,
     password: Option<String>,
@@ -308,7 +308,7 @@ mod mock_sspi {
     use super::*;
 
     #[derive(Debug, Clone, PartialEq, Eq)]
-    pub enum SspiAuthState {
+    pub(super) enum SspiAuthState {
         Initial,
         NegotiateSent,
         ChallengeReceived,
@@ -317,7 +317,7 @@ mod mock_sspi {
     }
 
     #[derive(Debug)]
-    pub struct SspiAuthManager;
+    pub(super) struct SspiAuthManager;
 
     impl SspiAuthManager {
         pub fn new(
@@ -369,4 +369,4 @@ mod mock_sspi {
 }
 
 #[cfg(not(windows))]
-pub use mock_sspi::{SspiAuthManager, SspiAuthState};
+pub(super) use mock_sspi::{SspiAuthManager, SspiAuthState};


### PR DESCRIPTION
## Summary
- Fix Windows SSPI compiler warnings by adjusting visibility modifiers
- Change `SspiAuthState` enum from `pub` to `pub(super)`
- Change `SspiAuthManager` struct from `pub` to `pub(super)`
- Update both Windows and mock implementations consistently
- Bump version to 0.9.4 for maintenance release

## Technical Details
The SSPI authentication types were using `pub` visibility but are only accessed within the resolver module and its submodules. Changed to `pub(super)` to:
- Maintain proper encapsulation
- Resolve compiler warnings about unused public visibility
- Match the existing pattern used in `sspi_auth_mock.rs`

## Test Plan
- [x] Build succeeds on macOS (cross-platform compatibility)
- [x] Clippy passes without warnings
- [x] Code formatting is correct
- [ ] Windows build validation (will be tested in CI)

This change maintains API compatibility within the resolver module while improving code quality.